### PR TITLE
fix: add npm overrides for vulnerable transitive deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,19 @@
     "@mitchallen/grid": "^0.1.25",
     "@mitchallen/grid-square": "^0.1.9",
     "@mitchallen/shuffle": "^0.1.7"
+  },
+  "overrides": {
+    "cookie": "0.7.0",
+    "send": "0.11.1",
+    "connect": "2.8.1",
+    "qs": "6.14.1",
+    "grunt": "1.5.2",
+    "cli": "1.0.0",
+    "request": "2.68.0",
+    "uglify-js": "2.4.24",
+    "serialize-javascript": "7.0.3",
+    "minimatch": "3.1.3",
+    "braces": "3.0.3",
+    "yargs-parser": "5.0.1"
   }
 }


### PR DESCRIPTION
## Automated npm overrides

This PR was created by `squish fix --overrides` to pin vulnerable transitive dependencies:

- `cookie` → `0.7.0`
- `send` → `0.11.1`
- `connect` → `2.8.1`
- `qs` → `6.14.1`
- `grunt` → `1.5.2`
- `cli` → `1.0.0`
- `request` → `2.68.0`
- `uglify-js` → `2.4.24`
- `serialize-javascript` → `7.0.3`
- `minimatch` → `3.1.3`
- `braces` → `3.0.3`
- `yargs-parser` → `5.0.1`

### Alerts addressed:

- **cookie** (low)
- **send** (low)
- **connect** (medium)
- **connect** (medium)
- **request** (medium)
- **qs** (high)
- **grunt** (high)
- **connect** (low)
- **qs** (high)
- **cli** (low)
- **request** (medium)
- **send** (low)
- **uglify-js** (critical)
- **send** (medium)
- **serialize-javascript** (medium)
- **serialize-javascript** (high)
- **minimatch** (high)
- **elliptic** (low)
- **qs** (medium)
- **braces** (high)
- **babel-traverse** (critical)
- **grunt** (high)
- **grunt** (medium)
- **yargs-parser** (medium)